### PR TITLE
feat: change default TF_VARS_FILE to terraform.tfvars.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1739420147@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0 AS prod
 
-LABEL konflux.additional-tags="tf-1.6.6-py-3.12-v0.3.0"
+LABEL konflux.additional-tags="tf-1.6.6-py-3.12-v0.3.1"
 
 USER 0
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,7 @@ export TERRAFORM_MODULE_WORK_DIR=${TERRAFORM_MODULE_WORK_DIR:-"${TMP_DIR}/module
 echo "Using TERRAFORM_MODULE_WORK_DIR directory: ${TERRAFORM_MODULE_WORK_DIR}"
 
 # Variables used by external-resources io to generate the required configuration
-export TF_VARS_FILE=${TF_VARS_FILE:-"${TERRAFORM_MODULE_WORK_DIR}/tfvars.json"}
+export TF_VARS_FILE=${TF_VARS_FILE:-"${TERRAFORM_MODULE_WORK_DIR}/terraform.tfvars.json"}
 export BACKEND_TF_FILE=${BACKEND_TF_FILE:-"${TERRAFORM_MODULE_WORK_DIR}/backend.tf"}
 export VARIABLES_TF_FILE=${VARIABLES_TF_FILE:-"${TERRAFORM_MODULE_WORK_DIR}/variables.tf"}
 
@@ -50,7 +50,7 @@ export VARIABLES_TF_FILE=${VARIABLES_TF_FILE:-"${TERRAFORM_MODULE_WORK_DIR}/vari
 export TERRAFORM_CMD="terraform -chdir=$TERRAFORM_MODULE_WORK_DIR"
 
 # the vars file path within the module directory
-export TERRAFORM_VARS="-var-file=tfvars.json"
+export TERRAFORM_VARS="-var-file=${TF_VARS_FILE}"
 
 export PLAN_FILE="${TMP_DIR}/plan"
 export PLAN_FILE_JSON="${TMP_DIR}/plan.json"


### PR DESCRIPTION
Use default `terraform.tfvars.json` for terraform to autoload when `-var-file` not specified, for better developer experience when local test. https://developer.hashicorp.com/terraform/language/values/variables#variable-definitions-tfvars-files