### PR TITLE
local terraform state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1739420147@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0 AS prod
 
-LABEL konflux.additional-tags="tf-1.6.6-py-3.12-v0.3.1"
+LABEL konflux.additional-tags="tf-1.6.6-py-3.12-v0.3.2"
 
 USER 0
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -133,6 +133,7 @@ function plan() {
     if [[ $ACTION == "Destroy" ]]; then
         PLAN_EXTRA_OPTIONS="-destroy"
     fi
+    # shellcheck disable=SC2086
     $TERRAFORM_CMD plan ${PLAN_EXTRA_OPTIONS} -out="${PLAN_FILE}" ${TERRAFORM_VARS} ${LOCK}
     $TERRAFORM_CMD show -json "${PLAN_FILE}" > "${PLAN_FILE_JSON}"
     run_hook "post_plan"
@@ -145,6 +146,7 @@ function apply() {
         $TERRAFORM_CMD output -json > "$OUTPUTS_FILE"
         run_hook "post_output"
     elif [[ $ACTION == "Destroy" ]] && [[ $DRY_RUN == "False" ]]; then
+        # shellcheck disable=SC2086
         $TERRAFORM_CMD destroy -auto-approve ${TERRAFORM_VARS}
     fi
     run_hook "post_apply"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -152,6 +152,26 @@ function apply() {
     run_hook "post_apply"
 }
 
+function fetch_terraform_state() {
+    run_hook "pre_fetch_terraform_state"
+    if [[ $DRY_RUN == "True" ]]; then
+        echo "Using local terraform state for dry-run mode"
+        # Use local state for dry-run mode
+        local tf_state="${WORK}/terraform.tfstate"
+        $TERRAFORM_CMD state pull > "${tf_state}"
+        cat - > "${BACKEND_TF_FILE}" <<EOF
+terraform {
+  backend "local" {
+    path = "${tf_state}"
+  }
+}
+EOF
+        # changing the backend needs a re-init
+        $TERRAFORM_CMD init -reconfigure
+    fi
+    run_hook "post_fetch_terraform_state"
+}
+
 validate_generate_tf_config
 create_working_directory
 run_hook "pre_run"
@@ -161,6 +181,7 @@ run_hook "pre_run"
 # into the module directory
 generate-tf-config
 init
+fetch_terraform_state
 plan
 apply
 run_hook "post_run"


### PR DESCRIPTION
Using a local terraform state in dry-run mode is much safer and easier for the hooks.

Ticket: [APPSRE-11561](https://issues.redhat.com/browse/APPSRE-11561)
