### PR TITLE
Fix: Store hook status before enabling script exit on errrors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1739420147@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0 AS prod
 
-LABEL konflux.additional-tags="tf-1.6.6-py-3.12-v0.3.2"
+LABEL konflux.additional-tags="tf-1.6.6-py-3.12-v0.3.3"
 
 USER 0
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,9 +108,9 @@ function run_hook() {
     set +e
     echo "Running hook: $HOOK_NAME"
     "$HOOK_SCRIPT" "$@"
+    local HOOK_STATUS=$?
     set -e
 
-    local HOOK_STATUS=$?
     if [[ $HOOK_STATUS -ne 0 ]]; then
         if [[ $HOOK_STATUS -eq 42 ]] && [[ $DRY_RUN == "True" ]]; then
             # hook requests retrigger of erv2 job. exit, but don't fail the job in dry-run mode


### PR DESCRIPTION
`set -e` changes `$?` so `HOOK_STATUS` is always 0