### PR TITLE
feat: allow hook early exit as success

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1739420147@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0 AS prod
 
-LABEL konflux.additional-tags="tf-1.6.6-py-3.12-v0.3.3"
+LABEL konflux.additional-tags="tf-1.6.6-py-3.12-v0.3.4"
 
 USER 0
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -112,8 +112,8 @@ function run_hook() {
     set -e
 
     if [[ $HOOK_STATUS -ne 0 ]]; then
-        if [[ $HOOK_STATUS -eq 42 ]] && [[ $DRY_RUN == "True" ]]; then
-            # hook requests retrigger of erv2 job. exit, but don't fail the job in dry-run mode
+        if [[ $HOOK_STATUS -eq 42 ]]; then
+            # to early exit as success, skip all remaining steps
             exit 0
         fi
         exit $HOOK_STATUS


### PR DESCRIPTION
`42` was used to `exit 0` when dry run, the new use case of blue/green deployment require it to `exit 0` on non dry run.

This change removes dry run check, let each hook consider dry run or not internally, entrypoint just check `42` as skip status to early exit.