### PR TITLE
feat: make docker tag compatible with renovate redhat versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1741850109@sha256:bafd57451de2daa71ed301b277d49bd120b474ed438367f087eac0b885a668dc AS prod
 
-LABEL konflux.additional-tags="tf-1.6.6-py-3.12-v0.3.4"
+LABEL konflux.additional-tags="0.3.5"
 
 USER 0
 


### PR DESCRIPTION
move version to the first part so renovate can use it to compare

doc: https://docs.renovatebot.com/modules/versioning/docker/

also need to add `loose` package rules for all ERv2 images.


[APPSRE-11640](https://issues.redhat.com/browse/APPSRE-11640)