### PR TITLE
feat: require lockfile to install providers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1741850109@sha256:bafd57451de2daa71ed301b277d49bd120b474ed438367f087eac0b885a668dc AS prod
 
-LABEL konflux.additional-tags="0.3.5"
+LABEL konflux.additional-tags="0.3.6"
 
 USER 0
 

--- a/terraform-provider-sync
+++ b/terraform-provider-sync
@@ -9,5 +9,6 @@ fi
 TF_INIT=$(mktemp -d)
 
 cp "${TERRAFORM_MODULE_SRC_DIR}"/versions.tf "${TF_INIT}"
+cp "${TERRAFORM_MODULE_SRC_DIR}"/.terraform.lock.hcl "${TF_INIT}"
 terraform -chdir="${TF_INIT}" init
 rm -rf "${TF_INIT}"


### PR DESCRIPTION
use lockfile `.terraform.lock.hcl` to use exact versions

note merge this after https://github.com/app-sre/er-base-terraform/pull/23 to test renovate versioning.

[APPSRE-11820](https://issues.redhat.com/browse/APPSRE-11820)