### PR TITLE
fix: copy module dir including dotfiles (.terraform.lock.hcl)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1741850109@sha256:bafd57451de2daa71ed301b277d49bd120b474ed438367f087eac0b885a668dc AS prod
 
-LABEL konflux.additional-tags="0.3.6"
+LABEL konflux.additional-tags="0.3.7"
 
 USER 0
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,8 +74,7 @@ function validate_generate_tf_config() {
 }
 
 function create_working_directory() {
-    mkdir -p "${TERRAFORM_MODULE_WORK_DIR}"
-    cp -rf "${TERRAFORM_MODULE_SRC_DIR}"/* "${TERRAFORM_MODULE_WORK_DIR}"/
+    cp -a "${TERRAFORM_MODULE_SRC_DIR}" "${TERRAFORM_MODULE_WORK_DIR}"
 }
 
 function run_hook() {


### PR DESCRIPTION
followup on https://github.com/app-sre/er-base-terraform/pull/24

`cp -rf` won't copy hidden files, we need to cp `.terraform.lock.hcl` into `TERRAFORM_MODULE_WORK_DIR`.

`cp -a` will create dest dir and copy all files from source.

[APPSRE-11820](https://issues.redhat.com/browse/APPSRE-11820)