### PR TITLE
Add LOCAL_STATE var to allow remote backend use during dry runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1741850109@sha256:bafd57451de2daa71ed301b277d49bd120b474ed438367f087eac0b885a668dc AS prod
 
-LABEL konflux.additional-tags="0.3.7"
+LABEL konflux.additional-tags="0.3.8"
 
 USER 0
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,7 @@ fi
 
 export DRY_RUN=${DRY_RUN:-"True"}
 export ACTION=${ACTION:-"Apply"}
+export LOCAL_STATE=${LOCAL_STATE:-"True"}
 
 if [[ $DRY_RUN != "True" ]] && [[ $DRY_RUN != "False" ]]; then
     echo "Invalid DRY_RUN option: $DRY_RUN. Must be 'True' or 'False'"
@@ -153,7 +154,7 @@ function apply() {
 
 function fetch_terraform_state() {
     run_hook "pre_fetch_terraform_state"
-    if [[ $DRY_RUN == "True" ]]; then
+    if [[ $DRY_RUN == "True" ]] && [[ $LOCAL_STATE == "True" ]]; then
         echo "Using local terraform state for dry-run mode"
         # Use local state for dry-run mode
         local tf_state="${WORK}/terraform.tfstate"


### PR DESCRIPTION
## Summary

Add `LOCAL_STATE` flag to allow remote backend use during dry runs.

Dependency for: https://github.com/app-sre/qontract-reconcile/pull/4967