### PR TITLE
chore(deps): bump terraform version to 1.13.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1764794109@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71 AS prod
 
-LABEL konflux.additional-tags="0.4.0"
+LABEL konflux.additional-tags="0.5.0"
 
 USER 0
 
@@ -10,7 +10,7 @@ ENV HOME="/home/app" \
     APP="/home/app/src"
 
 # Terraform versions and other related variables
-ENV TF_VERSION="1.6.6" \
+ENV TF_VERSION="1.7.5" \
     TF_PLUGIN_CACHE_DIR=${HOME}/.terraform.d/plugin-cache/ \
     TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV HOME="/home/app" \
     APP="/home/app/src"
 
 # Terraform versions and other related variables
-ENV TF_VERSION="1.7.5" \
+ENV TF_VERSION="1.13.4" \
     TF_PLUGIN_CACHE_DIR=${HOME}/.terraform.d/plugin-cache/ \
     TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=true
 


### PR DESCRIPTION
## Summary
APPSRE-12546

Bump to terraform 1.13.4

Dependency for https://github.com/app-sre/er-aws-cloudwatch/pull/61